### PR TITLE
Avoid instanceof

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "jasmine": "^4.0.2",
         "nyc": "^15.1.0",
         "prettier": "^2.5.1",
-        "typescript": "^4.6.2"
+        "typescript": "^4.6.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
@@ -2848,9 +2848,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4588,9 +4588,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {
@@ -5071,9 +5071,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "jasmine": "^4.0.2",
     "nyc": "^15.1.0",
     "prettier": "^2.5.1",
-    "typescript": "^4.6.2"
+    "typescript": "^4.6.4"
   }
 }

--- a/src/TextChange.ts
+++ b/src/TextChange.ts
@@ -233,7 +233,9 @@ export default class TextChange {
   }
 
   transformAgainst(delta: TextChange | Delta, priority?: boolean) {
-    const change = delta instanceof Delta ? new TextChange(null, delta) : delta;
+    const change = (delta as Delta).ops
+      ? new TextChange(null, delta as Delta)
+      : (delta as TextChange);
     return change.transform(this, !priority);
   }
 

--- a/src/TextDocument.ts
+++ b/src/TextDocument.ts
@@ -24,20 +24,21 @@ export default class TextDocument {
   selection: EditorRange | null;
 
   constructor(
-    lines?: TextDocument | Line[] | Delta,
+    linesOrDocOrDelta?: TextDocument | Line[] | Delta,
     selection: EditorRange | null = null,
   ) {
-    if (lines instanceof TextDocument) {
-      this.lines = lines.lines;
-      this.byId = lines.byId;
-      this._ranges = lines._ranges;
-      this.length = lines.length;
+    if ((linesOrDocOrDelta as TextDocument).lines) {
+      const textDocument = linesOrDocOrDelta as TextDocument;
+      this.lines = textDocument.lines;
+      this.byId = textDocument.byId;
+      this._ranges = textDocument._ranges;
+      this.length = textDocument.length;
     } else {
       this.byId = new Map();
-      if (Array.isArray(lines)) {
-        this.lines = lines;
-      } else if (lines) {
-        this.lines = Line.fromDelta(lines);
+      if (Array.isArray(linesOrDocOrDelta)) {
+        this.lines = linesOrDocOrDelta as Line[];
+      } else if (linesOrDocOrDelta) {
+        this.lines = Line.fromDelta(linesOrDocOrDelta as Delta);
       } else {
         this.lines = [Line.create()];
       }
@@ -180,11 +181,11 @@ export default class TextDocument {
     throwOnError?: boolean,
   ): TextDocument {
     let delta: Delta;
-    if (change instanceof TextChange) {
-      delta = change.delta;
-      selection = change.selection;
+    if ((change as TextChange).delta) {
+      delta = (change as TextChange).delta;
+      selection = (change as TextChange).selection;
     } else {
-      delta = change;
+      delta = change as Delta;
     }
 
     // If no change, do nothing


### PR DESCRIPTION
Because users of this library may use Delta and TextDocument as a dependency, `instanceof` may not always work if the data passed in is in a different package. Especially when linking for local development.