### PR TITLE
 Expand selection-only change optimization to `null` selections

### DIFF
--- a/src/TextDocument.ts
+++ b/src/TextDocument.ts
@@ -198,8 +198,8 @@ export default class TextDocument {
       return this;
     }
 
-    // Optimization for selection-only change
-    if (!delta.ops.length && selection) {
+    // If only selection has changed, all other state can be the same objects
+    if (!delta.ops.length) {
       return new TextDocument(this, selection);
     }
 

--- a/test/document.test.ts
+++ b/test/document.test.ts
@@ -146,3 +146,32 @@ describe('Text and Newline Insertion', () => {
     });
   });
 });
+
+describe('Selection Changes', () => {
+  it('Should reuse the lines of a document when the only change is setting selection', () => {
+    let doc = new TextDocument();
+    doc = doc.apply(doc.change.insert(0, 'Some example\nmultiline text'));
+
+    let selectedDoc = doc.apply(doc.change.select([1, 1]));
+
+    expect(selectedDoc.lines === doc.lines).toBeTruthy()
+  });
+
+  it('Should reuse the lines of a document when the only change is clearing selection', () => {
+    let doc = new TextDocument();
+    doc = doc.apply(doc.change.insert(0, 'Some example\nmultiline text').select(2));
+
+    let selectedDoc = doc.apply(doc.change.select(null));
+
+    expect(selectedDoc.lines === doc.lines).toBeTruthy();
+  });
+
+  it('Should retain the selection of a document when the selection of a change is undefined', () => {
+    let doc = new TextDocument();
+    doc = doc.apply(doc.change.insert(0, 'Some example\nmultiline text').select(2));
+
+    let undefinedSelectionDoc = doc.apply(doc.change);
+
+    expect(undefinedSelectionDoc.selection).toEqual(doc.selection);
+  });
+});


### PR DESCRIPTION
This fixes an issue where setting a selection to `null` with no other changes didn't flow through the "selection only change" optimization path. This resulted in extra processing (and incorrectly marked line changes) when selection moved away from an editor.